### PR TITLE
infra, twly-meeting-fetchers: specify `package-mode = false` to prevent installing themselves

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
-name = "transcript-timestamper-devenv"
+name = "transcript-timestamper-infra"
 version = "0.1.0"
-description = "Add timestampts to a transcript based on the audio file"
+description = "Transcript Timestamper infrastructure and project configuration."
 authors = [
     "Yi-Ting Yu <dududragoncat@gmail.com>",
     "Pin-Yen Lin <100340164+Lin-pinyen@users.noreply.github.com>",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,6 +9,7 @@ authors = [
 ]
 license = "MIT"
 readme = "README.md"
+package-mode = false
 
 
 [tool.poetry.dependencies]

--- a/twly-meeting-fetchers/pyproject.toml
+++ b/twly-meeting-fetchers/pyproject.toml
@@ -9,6 +9,7 @@ authors = [
 ]
 license = "MIT"
 readme = "README.md"
+package-mode = false
 
 
 [tool.poetry.dependencies]


### PR DESCRIPTION
We currently don't want to package transcript-timestamper-infra (the project root) and twly-meeting-fetchers, and we only wish to use Poetry to manage the dependency of their development environments.

This pull request sets `package-mode = false` in both of their `pyproject.toml`, making `poetry install` on them equivalent to `poetry install --no-root`.