### PR TITLE
infra: pyproject.toml: raise minimum Python version to 3.9

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -29,5 +29,5 @@ files = [
 
 [metadata]
 lock-version = "2.0"
-python-versions = "^3.8"
-content-hash = "366b8d82b760c124cd75aa2274fd57d00d11ce8f007ab0f81bf2f7641ef4db69"
+python-versions = "^3.9"
+content-hash = "3d4d4d70ce641955f88125838e9a36ab75bea23bdf1a1369df7d6523d4e60a3e"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ readme = "README.md"
 
 
 [tool.poetry.dependencies]
-python = "^3.8"
+python = "^3.9"
 ruff = "^0.5.5"
 
 


### PR DESCRIPTION
Raise the minimum supported Python versions to at least 3.9.
-   Python 3.8 will EOL at 2024-10.
-   Since Python 3.9, type hints of the form list[Telement] and
    dict[Tkey, Telement] are available, eliminating the need of
    ```python
    from typing import List, Dict.
    ```