### PR TITLE
Add the Nix layer

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -1,0 +1,18 @@
+# This file provides backward compatibility to nix < 2.4 clients
+{system ? builtins.currentSystem}: let
+  lock = builtins.fromJSON (builtins.readFile ./flake.lock);
+
+  root = lock.nodes.${lock.root};
+  inherit (lock.nodes.${root.inputs.flake-compat}.locked) owner repo rev narHash;
+
+  flake-compat = fetchTarball {
+    url = "https://github.com/${owner}/${repo}/archive/${rev}.tar.gz";
+    sha256 = narHash;
+  };
+
+  flake = import flake-compat {
+    inherit system;
+    src = ./.;
+  };
+in
+  flake.defaultNix

--- a/flake.lock
+++ b/flake.lock
@@ -85,6 +85,21 @@
         "type": "github"
       }
     },
+    "flake-compat": {
+      "locked": {
+        "lastModified": 1717312683,
+        "narHash": "sha256-FrlieJH50AuvagamEvWMIE6D2OAnERuDboFDYAED/dE=",
+        "owner": "nix-community",
+        "repo": "flake-compat",
+        "rev": "38fd3954cf65ce6faf3d0d45cd26059e059f07ea",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "flake-compat",
+        "type": "github"
+      }
+    },
     "flake-parts": {
       "inputs": {
         "nixpkgs-lib": "nixpkgs-lib"
@@ -270,6 +285,7 @@
         "alejandra": "alejandra",
         "devshell": "devshell",
         "dream2nix": "dream2nix",
+        "flake-compat": "flake-compat",
         "flake-parts": "flake-parts",
         "nixpkgs": "nixpkgs_2",
         "poetry2nix": "poetry2nix",

--- a/flake.lock
+++ b/flake.lock
@@ -189,6 +189,22 @@
         "type": "github"
       }
     },
+    "nixpkgs-dragonmapper": {
+      "locked": {
+        "lastModified": 1723957534,
+        "narHash": "sha256-dVdFIShl/atIB84bBEs8OAR/yeJezVrMLwfTeBTqJlU=",
+        "owner": "ShamrockLee",
+        "repo": "nixpkgs",
+        "rev": "8773d6657f9c5cccab00c050831344e544d5c4c9",
+        "type": "github"
+      },
+      "original": {
+        "owner": "ShamrockLee",
+        "ref": "dragonmappr",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
     "nixpkgs-lib": {
       "locked": {
         "lastModified": 1722555339,
@@ -199,6 +215,22 @@
       "original": {
         "type": "tarball",
         "url": "https://github.com/NixOS/nixpkgs/archive/a5d394176e64ab29c852d03346c1fc9b0b7d33eb.tar.gz"
+      }
+    },
+    "nixpkgs-pym3u8downloader": {
+      "locked": {
+        "lastModified": 1723932636,
+        "narHash": "sha256-bPdThQ77yzsqE10NRTNVTFs+Kjv4AAuXoLXPrK3rCuU=",
+        "owner": "ShamrockLee",
+        "repo": "nixpkgs",
+        "rev": "4826f444d46bee945743b12fafc636f534b7a2ee",
+        "type": "github"
+      },
+      "original": {
+        "owner": "ShamrockLee",
+        "ref": "pym3u8downloader",
+        "repo": "nixpkgs",
+        "type": "github"
       }
     },
     "nixpkgs_2": {
@@ -288,6 +320,8 @@
         "flake-compat": "flake-compat",
         "flake-parts": "flake-parts",
         "nixpkgs": "nixpkgs_2",
+        "nixpkgs-dragonmapper": "nixpkgs-dragonmapper",
+        "nixpkgs-pym3u8downloader": "nixpkgs-pym3u8downloader",
         "poetry2nix": "poetry2nix",
         "ruff-source": "ruff-source"
       }

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,388 @@
+{
+  "nodes": {
+    "alejandra": {
+      "inputs": {
+        "fenix": "fenix",
+        "flakeCompat": "flakeCompat",
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1660592437,
+        "narHash": "sha256-xFumnivtVwu5fFBOrTxrv6fv3geHKF04RGP23EsDVaI=",
+        "owner": "kamadorueda",
+        "repo": "alejandra",
+        "rev": "e7eac49074b70814b542fee987af2987dd0520b5",
+        "type": "github"
+      },
+      "original": {
+        "owner": "kamadorueda",
+        "ref": "3.0.0",
+        "repo": "alejandra",
+        "type": "github"
+      }
+    },
+    "devshell": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1722113426,
+        "narHash": "sha256-Yo/3loq572A8Su6aY5GP56knpuKYRvM2a1meP9oJZCw=",
+        "owner": "numtide",
+        "repo": "devshell",
+        "rev": "67cce7359e4cd3c45296fb4aaf6a19e2a9c757ae",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "devshell",
+        "type": "github"
+      }
+    },
+    "dream2nix": {
+      "inputs": {
+        "nixpkgs": "nixpkgs",
+        "purescript-overlay": "purescript-overlay",
+        "pyproject-nix": "pyproject-nix"
+      },
+      "locked": {
+        "lastModified": 1722526955,
+        "narHash": "sha256-fFS8aDnfK9Qfm2FLnQ8pqWk8FzvFEv5LvTuZTZLREnc=",
+        "owner": "nix-community",
+        "repo": "dream2nix",
+        "rev": "3fd4c14d3683baac8d1f94286ae14fe160888b51",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "dream2nix",
+        "type": "github"
+      }
+    },
+    "fenix": {
+      "inputs": {
+        "nixpkgs": [
+          "alejandra",
+          "nixpkgs"
+        ],
+        "rust-analyzer-src": "rust-analyzer-src"
+      },
+      "locked": {
+        "lastModified": 1657607339,
+        "narHash": "sha256-HaqoAwlbVVZH2n4P3jN2FFPMpVuhxDy1poNOR7kzODc=",
+        "owner": "nix-community",
+        "repo": "fenix",
+        "rev": "b814c83d9e6aa5a28d0cf356ecfdafb2505ad37d",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "fenix",
+        "type": "github"
+      }
+    },
+    "flake-parts": {
+      "inputs": {
+        "nixpkgs-lib": "nixpkgs-lib"
+      },
+      "locked": {
+        "lastModified": 1722555600,
+        "narHash": "sha256-XOQkdLafnb/p9ij77byFQjDf5m5QYl9b2REiVClC+x4=",
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "rev": "8471fe90ad337a8074e957b69ca4d0089218391d",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "type": "github"
+      }
+    },
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1710146030,
+        "narHash": "sha256-SZ5L6eA7HJ/nmkzGG7/ISclqe6oZdOZTNoesiInkXPQ=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "b1d9ab70662946ef0850d488da1c9019f3a9752a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "flakeCompat": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1650374568,
+        "narHash": "sha256-Z+s0J8/r907g149rllvwhb4pKi8Wam5ij0st8PwAh+E=",
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "rev": "b4a34015c698c7793d592d66adbab377907a2be8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "type": "github"
+      }
+    },
+    "nix-github-actions": {
+      "inputs": {
+        "nixpkgs": [
+          "poetry2nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1703863825,
+        "narHash": "sha256-rXwqjtwiGKJheXB43ybM8NwWB8rO2dSRrEqes0S7F5Y=",
+        "owner": "nix-community",
+        "repo": "nix-github-actions",
+        "rev": "5163432afc817cf8bd1f031418d1869e4c9d5547",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "nix-github-actions",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1720181791,
+        "narHash": "sha256-i4vJL12/AdyuQuviMMd1Hk2tsGt02hDNhA0Zj1m16N8=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "4284c2b73c8bce4b46a6adf23e16d9e2ec8da4bb",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-lib": {
+      "locked": {
+        "lastModified": 1722555339,
+        "narHash": "sha256-uFf2QeW7eAHlYXuDktm9c25OxOyCoUOQmh5SZ9amE5Q=",
+        "type": "tarball",
+        "url": "https://github.com/NixOS/nixpkgs/archive/a5d394176e64ab29c852d03346c1fc9b0b7d33eb.tar.gz"
+      },
+      "original": {
+        "type": "tarball",
+        "url": "https://github.com/NixOS/nixpkgs/archive/a5d394176e64ab29c852d03346c1fc9b0b7d33eb.tar.gz"
+      }
+    },
+    "nixpkgs_2": {
+      "locked": {
+        "lastModified": 1723282977,
+        "narHash": "sha256-oTK91aOlA/4IsjNAZGMEBz7Sq1zBS0Ltu4/nIQdYDOg=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "a781ff33ae258bbcfd4ed6e673860c3e923bf2cc",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-24.05",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "poetry2nix": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nix-github-actions": "nix-github-actions",
+        "nixpkgs": [
+          "nixpkgs"
+        ],
+        "systems": "systems_2",
+        "treefmt-nix": "treefmt-nix"
+      },
+      "locked": {
+        "lastModified": 1723343306,
+        "narHash": "sha256-/6sRkPq7/5weX2y0V8sQ29Sz35nt8kyj+BsFtkhgbJE=",
+        "owner": "nix-community",
+        "repo": "poetry2nix",
+        "rev": "4a1c112ff0c67f496573dc345bd0b2247818fc29",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "poetry2nix",
+        "type": "github"
+      }
+    },
+    "purescript-overlay": {
+      "inputs": {
+        "nixpkgs": [
+          "dream2nix",
+          "nixpkgs"
+        ],
+        "slimlock": "slimlock"
+      },
+      "locked": {
+        "lastModified": 1696022621,
+        "narHash": "sha256-eMjFmsj2G1E0Q5XiibUNgFjTiSz0GxIeSSzzVdoN730=",
+        "owner": "thomashoneyman",
+        "repo": "purescript-overlay",
+        "rev": "047c7933abd6da8aa239904422e22d190ce55ead",
+        "type": "github"
+      },
+      "original": {
+        "owner": "thomashoneyman",
+        "repo": "purescript-overlay",
+        "type": "github"
+      }
+    },
+    "pyproject-nix": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1702448246,
+        "narHash": "sha256-hFg5s/hoJFv7tDpiGvEvXP0UfFvFEDgTdyHIjDVHu1I=",
+        "owner": "davhau",
+        "repo": "pyproject.nix",
+        "rev": "5a06a2697b228c04dd2f35659b4b659ca74f7aeb",
+        "type": "github"
+      },
+      "original": {
+        "owner": "davhau",
+        "ref": "dream2nix",
+        "repo": "pyproject.nix",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "alejandra": "alejandra",
+        "devshell": "devshell",
+        "dream2nix": "dream2nix",
+        "flake-parts": "flake-parts",
+        "nixpkgs": "nixpkgs_2",
+        "poetry2nix": "poetry2nix",
+        "ruff-source": "ruff-source"
+      }
+    },
+    "ruff-source": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1721918821,
+        "narHash": "sha256-dqfK6YdAV4cdUYB8bPE9I5FduBJ90RxUA7TMvcVq6Zw=",
+        "owner": "astral-sh",
+        "repo": "ruff",
+        "rev": "fc16d8d04d86aa94a8aac14bbb87089b64d443a1",
+        "type": "github"
+      },
+      "original": {
+        "owner": "astral-sh",
+        "ref": "0.5.5",
+        "repo": "ruff",
+        "type": "github"
+      }
+    },
+    "rust-analyzer-src": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1657557289,
+        "narHash": "sha256-PRW+nUwuqNTRAEa83SfX+7g+g8nQ+2MMbasQ9nt6+UM=",
+        "owner": "rust-lang",
+        "repo": "rust-analyzer",
+        "rev": "caf23f29144b371035b864a1017dbc32573ad56d",
+        "type": "github"
+      },
+      "original": {
+        "owner": "rust-lang",
+        "ref": "nightly",
+        "repo": "rust-analyzer",
+        "type": "github"
+      }
+    },
+    "slimlock": {
+      "inputs": {
+        "nixpkgs": [
+          "dream2nix",
+          "purescript-overlay",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1688610262,
+        "narHash": "sha256-Wg0ViDotFWGWqKIQzyYCgayeH8s4U1OZcTiWTQYdAp4=",
+        "owner": "thomashoneyman",
+        "repo": "slimlock",
+        "rev": "b5c6cdcaf636ebbebd0a1f32520929394493f1a6",
+        "type": "github"
+      },
+      "original": {
+        "owner": "thomashoneyman",
+        "repo": "slimlock",
+        "type": "github"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    },
+    "systems_2": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "id": "systems",
+        "type": "indirect"
+      }
+    },
+    "treefmt-nix": {
+      "inputs": {
+        "nixpkgs": [
+          "poetry2nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1719749022,
+        "narHash": "sha256-ddPKHcqaKCIFSFc/cvxS14goUhCOAwsM1PbMr0ZtHMg=",
+        "owner": "numtide",
+        "repo": "treefmt-nix",
+        "rev": "8df5ff62195d4e67e2264df0b7f5e8c9995fd0bd",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "treefmt-nix",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -8,6 +8,9 @@
   inputs.devshell.inputs.nixpkgs.follows = "nixpkgs";
   # Build ruff of custom version with dream2nix
   inputs.dream2nix.url = "github:nix-community/dream2nix";
+  # The branch name contains an unfortunate typo.
+  inputs.nixpkgs-dragonmapper.url = "github:ShamrockLee/nixpkgs/dragonmappr";
+  inputs.nixpkgs-pym3u8downloader.url = "github:ShamrockLee/nixpkgs/pym3u8downloader";
   inputs.poetry2nix.url = "github:nix-community/poetry2nix";
   inputs.poetry2nix.inputs.nixpkgs.follows = "nixpkgs";
   inputs.ruff-source.url = "github:astral-sh/ruff/0.5.5";

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,143 @@
+{
+  inputs.nixpkgs.url = "github:NixOS/nixpkgs/nixos-24.05";
+  inputs.flake-parts.url = "github:hercules-ci/flake-parts";
+  inputs.alejandra.url = "github:kamadorueda/alejandra/3.0.0";
+  inputs.alejandra.inputs.nixpkgs.follows = "nixpkgs";
+  inputs.devshell.url = "github:numtide/devshell";
+  inputs.devshell.inputs.nixpkgs.follows = "nixpkgs";
+  # Build ruff of custom version with dream2nix
+  inputs.dream2nix.url = "github:nix-community/dream2nix";
+  inputs.poetry2nix.url = "github:nix-community/poetry2nix";
+  inputs.poetry2nix.inputs.nixpkgs.follows = "nixpkgs";
+  inputs.ruff-source.url = "github:astral-sh/ruff/0.5.5";
+  inputs.ruff-source.flake = false;
+
+  outputs = {self, ...} @ inputs: let
+    inherit (inputs.nixpkgs) lib;
+  in
+    inputs.flake-parts.lib.mkFlake {inherit inputs;} {
+      imports = [
+        inputs.devshell.flakeModule
+      ];
+      perSystem = {
+        config,
+        self',
+        inputs',
+        pkgs,
+        system,
+        ...
+      }: let
+        poetry2nix = inputs.poetry2nix.lib.mkPoetry2Nix {inherit pkgs;};
+        callDream2NixModule = module:
+          inputs.dream2nix.lib.evalModules {
+            packageSets.nixpkgs = pkgs;
+            modules = [
+              module
+              {
+                paths.projectRoot = ./.;
+                paths.projectRootFile = ./flake.nix;
+                paths.package = ./.;
+              }
+            ];
+          };
+      in {
+        devshells.infra = {
+          packages = with self'.packages; [
+            alejandra
+            ruff
+            poetry
+            shfmt
+            treefmt
+          ];
+        };
+        devShells.poetryenv-transcript-timestamper = poetry2nix.mkPoetryEnv {
+          projectDir = ./transcript-timestamper;
+          groups = ["dev"];
+          checkGroups = ["test"];
+        };
+        devShells.poetryenv-transcript-timestamper-ui = poetry2nix.mkPoetryEnv {
+          projectDir = ./transcript-timestamper-ui;
+        };
+        devShells.poetryenv-twly-meeting-fetchers = (poetry2nix.mkPoetryEnv {
+          projectDir = ./twly-meeting-fetchers;
+          groups = ["dev"];
+        }).env.overrideAttrs (finalAttrs: previousAttrs: {
+          buildInputs = previousAttrs.buildInputs or [] ++ (with pkgs; [
+            ffmpeg-headless
+          ]);
+        });
+        devShells.default = config.devShells.infra;
+        packages = {
+          inherit
+            (pkgs)
+            poetry
+            shfmt
+            treefmt
+            ;
+          alejandra =
+            inputs'.alejandra.packages.default
+            or (import inputs.nixpkgs {
+              overlays = [inputs.alejandra.overlay];
+              inherit system;
+            })
+            .alejandra;
+          ruff = callDream2NixModule (
+            {
+              config,
+              lib,
+              dream2nix,
+              ...
+            }: {
+              imports = [
+                dream2nix.modules.dream2nix.rust-cargo-lock
+                dream2nix.modules.dream2nix.buildRustPackage
+              ];
+
+              deps = {nixpkgs, ...}: {
+                inherit
+                  (nixpkgs)
+                  installShellFiles
+                  rust-jemalloc-sys
+                  ;
+                CoreService =
+                  if nixpkgs.stdenv.isDarwin
+                  then nixpkgs.darwin.apple_sdk.frameworks.CoreService
+                  else null;
+                # For phases
+                ruff-nixpkgs = nixpkgs.ruff;
+              };
+
+              name = lib.mkForce "ruff";
+              version = lib.mkForce "0.5.5";
+
+              mkDerivation = {
+                src = inputs.ruff-source.outPath;
+                nativeBuildInputs = with config.deps; [
+                  installShellFiles
+                ];
+                buildInputs = with config.deps; [
+                  rust-jemalloc-sys
+                  CoreService
+                ];
+                inherit
+                  (config.deps.ruff-nixpkgs)
+                  postInstall
+                  ;
+              };
+
+              public = {
+                meta = {
+                  inherit
+                    (config.deps.ruff-nixpkgs.meta)
+                    description
+                    mainProgram
+                    ;
+                };
+              };
+            }
+          );
+        };
+      };
+      systems = lib.attrNames inputs.nixpkgs.legacyPackages;
+    };
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,5 +1,6 @@
 {
   inputs.nixpkgs.url = "github:NixOS/nixpkgs/nixos-24.05";
+  inputs.flake-compat.url = "github:nix-community/flake-compat";
   inputs.flake-parts.url = "github:hercules-ci/flake-parts";
   inputs.alejandra.url = "github:kamadorueda/alejandra/3.0.0";
   inputs.alejandra.inputs.nixpkgs.follows = "nixpkgs";
@@ -19,6 +20,13 @@
       imports = [
         inputs.devshell.flakeModule
       ];
+      flake = {
+        pythonPackageExtensions = {
+          transcript-timestamper = import ./transcript-timestamper/python-packages-extension.nix;
+          transcript-timestamper-ui = import ./transcript-timestamper-ui/python-packages-extension.nix;
+          twly-meeting-fetchers = import ./twly-meeting-fetchers/python-packages-extension.nix;
+        };
+      };
       perSystem = {
         config,
         self',
@@ -40,103 +48,190 @@
               }
             ];
           };
-      in {
-        devshells.infra = {
-          packages = with self'.packages; [
-            alejandra
-            ruff
-            poetry
-            shfmt
-            treefmt
-          ];
-        };
-        devShells.poetryenv-transcript-timestamper = poetry2nix.mkPoetryEnv {
-          projectDir = ./transcript-timestamper;
-          groups = ["dev"];
-          checkGroups = ["test"];
-        };
-        devShells.poetryenv-transcript-timestamper-ui = poetry2nix.mkPoetryEnv {
-          projectDir = ./transcript-timestamper-ui;
-        };
-        devShells.poetryenv-twly-meeting-fetchers = (poetry2nix.mkPoetryEnv {
-          projectDir = ./twly-meeting-fetchers;
-          groups = ["dev"];
-        }).env.overrideAttrs (finalAttrs: previousAttrs: {
-          buildInputs = previousAttrs.buildInputs or [] ++ (with pkgs; [
-            ffmpeg-headless
-          ]);
-        });
-        devShells.default = config.devShells.infra;
-        packages = {
+        pythons = {
           inherit
             (pkgs)
-            poetry
-            shfmt
-            treefmt
+            python3
+            python39
+            python310
+            python311
+            python312
+            pypy3
+            pypy39
+            pypy310
             ;
-          alejandra =
-            inputs'.alejandra.packages.default
-            or (import inputs.nixpkgs {
-              overlays = [inputs.alejandra.overlay];
-              inherit system;
-            })
-            .alejandra;
-          ruff = callDream2NixModule (
-            {
-              config,
-              lib,
-              dream2nix,
-              ...
-            }: {
-              imports = [
-                dream2nix.modules.dream2nix.rust-cargo-lock
-                dream2nix.modules.dream2nix.buildRustPackage
+        };
+      in {
+        devshells =
+          {
+            infra = {
+              packages = with self'.packages; [
+                alejandra
+                ruff
+                poetry
+                shfmt
+                treefmt
               ];
-
-              deps = {nixpkgs, ...}: {
-                inherit
-                  (nixpkgs)
-                  installShellFiles
-                  rust-jemalloc-sys
-                  ;
-                CoreService =
-                  if nixpkgs.stdenv.isDarwin
-                  then nixpkgs.darwin.apple_sdk.frameworks.CoreService
-                  else null;
-                # For phases
-                ruff-nixpkgs = nixpkgs.ruff;
-              };
-
-              name = lib.mkForce "ruff";
-              version = lib.mkForce "0.5.5";
-
-              mkDerivation = {
-                src = inputs.ruff-source.outPath;
-                nativeBuildInputs = with config.deps; [
-                  installShellFiles
+            };
+          }
+          // lib.concatMapAttrs (pythonName: python: {
+            "pythondev-twly-meeting-fetchers_${pythonName}" = {
+              packages =
+                [
+                  (self'.packages."${pythonName}-overridden-transcript-timestamper-ui".withPackages (ps: (with ps; [
+                    pandas
+                    pypdf
+                    py-pdf-parser
+                    selenium
+                  ])))
+                ]
+                ++ (with pkgs; [
+                  ffmpeg-headless
+                ]);
+            };
+          })
+          pythons;
+        devShells =
+          {
+            default = config.devShells.infra;
+          }
+          // lib.genAttrs [
+            "poetryenv-transcript-timestamper"
+            "poetryenv-transcript-timestamper-ui"
+            "poetryenv-twly-meeting-fetchers"
+            "pythondev-transcript-timestamper"
+            "pythondev-transcript-timestamper-ui"
+            "pythondev-twly-meeting-fetchers"
+          ] (name: self'.devShells."${name}_python3")
+          // lib.concatMapAttrs (pythonName: python: {
+            "poetryenv-transcript-timestamper_${pythonName}" = poetry2nix.mkPoetryEnv {
+              projectDir = ./transcript-timestamper;
+              groups = ["dev"];
+              checkGroups = ["test"];
+              inherit python;
+            };
+            # PySide6 currently doesn't build through poetry2nix.
+            # Use `pythondev-transcript-timestamper-ui` instead.
+            "poetryenv-transcript-timestamper-ui_${pythonName}" = poetry2nix.mkPoetryEnv {
+              projectDir = ./transcript-timestamper-ui;
+              inherit python;
+            };
+            "poetryenv-twly-meeting-fetchers_${pythonName}" =
+              (poetry2nix.mkPoetryEnv {
+                projectDir = ./twly-meeting-fetchers;
+                groups = ["dev"];
+                inherit python;
+              })
+              .env
+              .overrideAttrs (finalAttrs: previousAttrs: {
+                buildInputs =
+                  previousAttrs.buildInputs
+                  or []
+                  ++ (with pkgs; [
+                    ffmpeg-headless
+                  ]);
+              });
+            "pythondev-transcript-timestamper_${pythonName}" =
+              self'.packages."${pythonName}-overridden-transcript-timestamper".pkgs.transcript-timestamper;
+            "pythondev-transcript-timestamper-ui_${pythonName}" =
+              self'.packages."${pythonName}-overridden-transcript-timestamper-ui".pkgs.transcript-timestamper-ui;
+          })
+          pythons;
+        packages =
+          {
+            inherit
+              (pkgs)
+              poetry
+              shfmt
+              treefmt
+              ;
+            alejandra =
+              inputs'.alejandra.packages.default
+              or (import inputs.nixpkgs {
+                overlays = [inputs.alejandra.overlay];
+                inherit system;
+              })
+              .alejandra;
+            ruff = callDream2NixModule (
+              {
+                config,
+                lib,
+                dream2nix,
+                ...
+              }: {
+                imports = [
+                  dream2nix.modules.dream2nix.rust-cargo-lock
+                  dream2nix.modules.dream2nix.buildRustPackage
                 ];
-                buildInputs = with config.deps; [
-                  rust-jemalloc-sys
-                  CoreService
-                ];
-                inherit
-                  (config.deps.ruff-nixpkgs)
-                  postInstall
-                  ;
-              };
 
-              public = {
-                meta = {
+                deps = {nixpkgs, ...}: {
                   inherit
-                    (config.deps.ruff-nixpkgs.meta)
-                    description
-                    mainProgram
+                    (nixpkgs)
+                    installShellFiles
+                    rust-jemalloc-sys
+                    ;
+                  CoreService =
+                    if nixpkgs.stdenv.isDarwin
+                    then nixpkgs.darwin.apple_sdk.frameworks.CoreService
+                    else null;
+                  # For phases
+                  ruff-nixpkgs = nixpkgs.ruff;
+                };
+
+                name = lib.mkForce "ruff";
+                version = lib.mkForce "0.5.5";
+
+                mkDerivation = {
+                  src = inputs.ruff-source.outPath;
+                  nativeBuildInputs = with config.deps; [
+                    installShellFiles
+                  ];
+                  buildInputs = with config.deps; [
+                    rust-jemalloc-sys
+                    CoreService
+                  ];
+                  inherit
+                    (config.deps.ruff-nixpkgs)
+                    postInstall
                     ;
                 };
-              };
-            }
-          );
-        };
+
+                public = {
+                  meta = {
+                    inherit
+                      (config.deps.ruff-nixpkgs.meta)
+                      description
+                      mainProgram
+                      ;
+                  };
+                };
+              }
+            );
+          }
+          // lib.mapAttrs' (pythonName: python: {
+            name = "${pythonName}-overridden-transcript-timestamper";
+            value = python.override {
+              packageOverrides = self.pythonPackageExtensions.transcript-timestamper;
+            };
+          })
+          pythons
+          // lib.mapAttrs' (pythonName: python: {
+            name = "${pythonName}-overridden-transcript-timestamper-ui";
+            value = python.override {
+              packageOverrides = lib.composeManyExtensions [
+                self.pythonPackageExtensions.transcript-timestamper
+                self.pythonPackageExtensions.transcript-timestamper-ui
+              ];
+            };
+          })
+          pythons
+          // lib.mapAttrs' (pythonName: python: {
+            name = "${pythonName}-overridden-twly-meeting-fetchers";
+            value = python.override {
+              packageOverrides = self.pythonPackageExtensions.twly-meeting-fetchers;
+            };
+          })
+          pythons;
       };
       systems = lib.attrNames inputs.nixpkgs.legacyPackages;
     };

--- a/transcript-timestamper-ui/package.nix
+++ b/transcript-timestamper-ui/package.nix
@@ -1,0 +1,47 @@
+{
+  lib,
+  # Build helpers
+  buildPythonPackage,
+  # Native build inputs
+  poetry-core,
+  # Build inputs
+  pyside6,
+  transcript-timestamper,
+}: let
+  pyprojectTOMLAttrs = lib.importTOML ./pyproject.toml;
+  # TODO(@ShamrockLee):
+  # Switch to pyprojectTomlAttrs.project
+  # once python-poetry/poetry#9135 gets merged and released.
+  pyprojectTOMLMetadata = pyprojectTOMLAttrs.tool.poetry;
+in
+  buildPythonPackage {
+    pname = "transcript-timestamper-ui";
+    inherit (pyprojectTOMLMetadata) version;
+    pyproject = true;
+
+    src = with lib.fileset;
+      toSource {
+        root = ./.;
+        # Get the filesets of files that are both
+        # - In this directory
+        # - Tracked by the Git repository (whose project root is the parent directory)
+        fileset = intersection ./. (gitTracked ../.);
+      };
+
+    build-system = [poetry-core];
+
+    dependencies = [
+      pyside6
+      transcript-timestamper
+    ];
+
+    pythonImportsCheck = [
+      "transcript_timestamper_ui"
+      "transcript_timestamper_ui.qt"
+    ];
+
+    meta = {
+      description = pyprojectTOMLMetadata.description;
+      licenses = lib.getLicenseFromSpdxId pyprojectTOMLMetadata.license;
+    };
+  }

--- a/transcript-timestamper-ui/python-packages-extension.nix
+++ b/transcript-timestamper-ui/python-packages-extension.nix
@@ -1,0 +1,3 @@
+final: prev: {
+  transcript-timestamper-ui = final.callPackage ./package.nix {};
+}

--- a/transcript-timestamper/package.nix
+++ b/transcript-timestamper/package.nix
@@ -5,6 +5,7 @@
   # Native build inputs
   poetry-core,
   # Build inputs
+  dragonmapper,
   numpy,
   pandas,
   whisper,
@@ -32,6 +33,7 @@ in
     build-system = [poetry-core];
 
     dependencies = [
+      dragonmapper
       numpy
       pandas
       whisper

--- a/transcript-timestamper/package.nix
+++ b/transcript-timestamper/package.nix
@@ -1,0 +1,46 @@
+{
+  lib,
+  # Build helpers
+  buildPythonPackage,
+  # Native build inputs
+  poetry-core,
+  # Build inputs
+  numpy,
+  pandas,
+  whisper,
+}: let
+  pyprojectTOMLAttrs = lib.importTOML ./pyproject.toml;
+  # TODO(@ShamrockLee):
+  # Switch to pyprojectTomlAttrs.project
+  # once python-poetry/poetry#9135 gets merged and released.
+  pyprojectTOMLMetadata = pyprojectTOMLAttrs.tool.poetry;
+in
+  buildPythonPackage {
+    pname = "transcript-timestamper";
+    inherit (pyprojectTOMLMetadata) version;
+    pyproject = true;
+
+    src = with lib.fileset;
+      toSource {
+        root = ./.;
+        # Get the filesets of files that are both
+        # - In this directory
+        # - Tracked by the Git repository (whose project root is the parent directory)
+        fileset = intersection ./. (gitTracked ../.);
+      };
+
+    build-system = [poetry-core];
+
+    dependencies = [
+      numpy
+      pandas
+      whisper
+    ];
+
+    pythonImportsCheck = ["transcript_timestamper"];
+
+    meta = {
+      description = pyprojectTOMLMetadata.description;
+      licenses = lib.getLicenseFromSpdxId pyprojectTOMLMetadata.license;
+    };
+  }

--- a/transcript-timestamper/python-packages-extension.nix
+++ b/transcript-timestamper/python-packages-extension.nix
@@ -1,0 +1,3 @@
+final: prev: {
+  transcript-timestamper = final.callPackage ./package.nix {};
+}

--- a/transcript-timestamper/python-packages-extension.nix
+++ b/transcript-timestamper/python-packages-extension.nix
@@ -1,3 +1,21 @@
-final: prev: {
+final: prev: let
+  this-flake = import ../. { inherit (final.stdenv.hostPlatform) system; };
+  inherit
+    (this-flake.inputs)
+    nixpkgs-dragonmapper
+    ;
+  callPackageFromNixpkgs = nixpkgs: subPath:
+    final.callPackage "${nixpkgs}/${subPath}";
+  callPythonModuleFromNixpkgs = nixpkgs: subPath:
+    callPackageFromNixpkgs nixpkgs "pkgs/development/python-modules/${subPath}";
+in {
+  dragonmapper = callPythonModuleFromNixpkgs nixpkgs-dragonmapper "dragonmapper" {};
+
+  # dragonmapper dependency
+  hanzidentifier = callPythonModuleFromNixpkgs nixpkgs-dragonmapper "hanzidentifier" {};
+
   transcript-timestamper = final.callPackage ./package.nix {};
+
+  # dragonmapper dependency
+  zhon = callPythonModuleFromNixpkgs nixpkgs-dragonmapper "zhon" {};
 }

--- a/twly-meeting-fetchers/python-packages-extension.nix
+++ b/twly-meeting-fetchers/python-packages-extension.nix
@@ -1,0 +1,2 @@
+final: prev: {
+}

--- a/twly-meeting-fetchers/python-packages-extension.nix
+++ b/twly-meeting-fetchers/python-packages-extension.nix
@@ -1,2 +1,19 @@
-final: prev: {
+final: prev: let
+  this-flake = import ../. { inherit (final.stdenv.hostPlatform) system; };
+  inherit
+    (this-flake.inputs)
+    nixpkgs-pym3u8downloader
+    ;
+  callPackageFromNixpkgs = nixpkgs: subPath:
+    final.callPackage "${nixpkgs}/${subPath}";
+  callPythonModuleFromNixpkgs = nixpkgs: subPath:
+    callPackageFromNixpkgs nixpkgs "pkgs/development/python-modules/${subPath}";
+in {
+  # pym3u8downloader dependency
+  pycolorecho = callPythonModuleFromNixpkgs nixpkgs-pym3u8downloader "pycolorecho" {};
+
+  # pym3u8downloader dependency
+  pyloggermanager = callPythonModuleFromNixpkgs nixpkgs-pym3u8downloader "pyloggermanager" {};
+
+  pym3u8downloader = callPythonModuleFromNixpkgs nixpkgs-pym3u8downloader "pym3u8downloader" {};
 }


### PR DESCRIPTION
This PR adds the Nix-based development environment based on both [poetry2nix](https://github.com/nix-community/poetry2nix) (`poetryenv-*`) and the Nixpkgs-conformant pattern (`pythondev-*`).

The `pythonPackageExtensions` flake attributes and the `python-package-extension.nix` files enable bidirectional integration between `transcript-timestamper[-ui]` and Nixpkgs's `python3Packages` set.

This PR also adds the `checks` flake output, which we could use to add GitHub actions in future PRs.

Lastly, these changes enabled me to develop this project on NixOS, which is notoriously hard to work with third-party pre-built binaries without integration.