### PR TITLE
Add flake package checks and fix builds

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -59,12 +59,21 @@
             python310
             python311
             python312
-            pypy3
-            pypy39
-            pypy310
             ;
         };
+        # Python packages with all its modules in the Nixpkgs binary cache
+        binaryCachedPythons =
+          lib.filterAttrs (
+            pythonName: python:
+              pkgs."${pythonName}Packages".recurseForDerivations or false
+          )
+          pythons;
       in {
+        checks = lib.concatMapAttrs (pythonName: python: {
+          "transcript-timestamper_${pythonName}" = self'.packages."${pythonName}-overridden-transcript-timestamper".pkgs.transcript-timestamper;
+          "transcript-timestamper-ui_${pythonName}" = self'.packages."${pythonName}-overridden-transcript-timestamper-ui".pkgs.transcript-timestamper-ui;
+        })
+        binaryCachedPythons;
         devshells =
           {
             infra = {

--- a/transcript-timestamper/package.nix
+++ b/transcript-timestamper/package.nix
@@ -4,6 +4,7 @@
   buildPythonPackage,
   # Native build inputs
   poetry-core,
+  pytestCheckHook,
   # Build inputs
   dragonmapper,
   numpy,
@@ -37,6 +38,13 @@ in
       numpy
       pandas
       whisper
+    ];
+
+    # There is currently no pytest tests.
+    doCheck = false;
+
+    nativeCheckInputs = [
+      pytestCheckHook
     ];
 
     pythonImportsCheck = ["transcript_timestamper"];


### PR DESCRIPTION
This PR contains the leftover fixes I forgot to push onto #8.

Add flake checks.

Add missing `dragonmapper` override argument for transcript-timestamper.

Remove PyPy from Pythons, as the builds of large packages (e.g., PySide6) often fail against them.

Add pytestCheckHook but disable tests for transcript-timestamper. This way, pytestCheckPhase will be available in the development environment but won't run during build and fail because of the lack of PyTest tests.