### PR TITLE
Improvement the GitHub workflows' caching and granularity

### DIFF
--- a/.github/actions/install-nix/action.yml
+++ b/.github/actions/install-nix/action.yml
@@ -2,11 +2,6 @@ name: Install Nix pinned
 
 description: Install a pinned version of Nix.
 
-inputs:
-  save-gha-cache:
-    description: "Whether to save to the GitHub Actions cache."
-    default: false
-
 runs:
   using: composite
   steps:
@@ -15,5 +10,3 @@ runs:
         # Workaround https://github.com/nix-community/dream2nix/issues/1037
         install_url: "https://releases.nixos.org/nix/nix-2.18.5/install"
     - uses: DeterminateSystems/magic-nix-cache-action@main
-      with:
-        use-gha-cache: ${{inputs.save-gha-cache}}

--- a/.github/actions/install-nix/action.yml
+++ b/.github/actions/install-nix/action.yml
@@ -2,6 +2,24 @@ name: Install Nix pinned
 
 description: Install a pinned version of Nix.
 
+inputs:
+  use-cachix:
+    description: Whether to use the Cachix-backed Nix binary cache
+    default: true
+
+  push-to-cachix:
+    description: Whether to push/write to the Cachix cache
+    default: false
+
+  paths-to-push:
+    description: |
+      Whitespace separated paths (result symlinks) to push to the Cachix cache.
+      Leave empty to push every build result.
+
+  cachix-auth-token:
+    description: |
+      The secret CACHIX_AUTH_TOKEN for writing/pushing to the cache.
+      The cache transcript-timestamper is public, so we don't need authentication to read from it.
 runs:
   using: composite
   steps:
@@ -10,3 +28,13 @@ runs:
         # Workaround https://github.com/nix-community/dream2nix/issues/1037
         install_url: "https://releases.nixos.org/nix/nix-2.18.5/install"
     - uses: DeterminateSystems/magic-nix-cache-action@main
+    - uses: cachix/cachix-action@v15
+      if: ${{inputs.use-cachix}}
+      with:
+        # Cache transcript-timestamper is a public Nix binary cache
+        # created by @ShamrockLee, provided by Cachix
+        # https://app.cachix.org/cache/transcript-timestamper
+        name: transcript-timestamper
+        skipPush: ${{inputs.push-to-cachix != true}}
+        pathsToPush: ${{inputs.paths-to-push}}
+        authToken: '${{inputs.cachix-auth-token}}'

--- a/.github/workflows/test-main.yml
+++ b/.github/workflows/test-main.yml
@@ -15,7 +15,17 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/install-nix
-      - name: Test the infra environment used by other GitHub workflows.
-        run: nix develop -c echo infra development environment success
       - name: Test the Nix flake
         run: nix flake check --keep-going
+
+  test-nix-infra-env:
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+    runs-on: ${{matrix.os}}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/install-nix
+      - name: Test the infra environment used by other GitHub workflows.
+        run: nix develop -c echo infra development environment success

--- a/.github/workflows/test-main.yml
+++ b/.github/workflows/test-main.yml
@@ -5,8 +5,25 @@ on:
     branches: [main]
 
 jobs:
+  push-ruff-pinned:
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+    runs-on: ${{matrix.os}}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/install-nix
+        with:
+          push-to-cachix: true
+          paths-to-push: result
+          # This is the repository secret, set by @ShamrockLee
+          cachix-auth-token: ${{secrets.CACHIX_AUTH_TOKEN_RW}}
+      - run: nix build .#ruff_d2n
 
   nix-flake-check:
+    if: ${{ always() }}
+    needs: push-ruff-pinned
     strategy:
       fail-fast: false
       matrix:
@@ -19,6 +36,8 @@ jobs:
         run: nix flake check --keep-going
 
   test-nix-infra-env:
+    if: ${{ always() }}
+    needs: push-ruff-pinned
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/test-main.yml
+++ b/.github/workflows/test-main.yml
@@ -15,9 +15,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/install-nix
-        with:
-          save-gha-cache: true
-      - name: Add the relevant ruff build to the GitHub Actions Cache.
+      - name: Test the infra environment used by other GitHub workflows.
         run: nix develop -c echo infra development environment success
       - name: Test the Nix flake
         run: nix flake check --keep-going

--- a/.github/workflows/test-pull-requests.yml
+++ b/.github/workflows/test-pull-requests.yml
@@ -30,6 +30,22 @@ jobs:
       - name: Check if the codebase is formatted
         run: nix develop -c treefmt --ci
 
+  poetry-run-ruff:
+    runs-on: [ubuntu-latest]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/install-nix
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{matrix.python-version}}
+      - uses: abatilo/actions-poetry@v2
+      - name: "Run poetry install for infra"
+        uses: ./.github/actions/poetry-install
+      - name: Run ruff check
+        run: poetry run -- ruff check .
+      - name: Run ruff format check
+        run: poetry run -- ruff format --check .
+
   test-with-poetry:
     strategy:
       fail-fast: false

--- a/.github/workflows/test-pull-requests.yml
+++ b/.github/workflows/test-pull-requests.yml
@@ -1,4 +1,4 @@
-name: Test feature branches
+name: Test PRs
 
 on:
   pull_request:

--- a/nix-deps/d2n_ruff.nix
+++ b/nix-deps/d2n_ruff.nix
@@ -1,0 +1,66 @@
+{
+  config,
+  lib,
+  dream2nix,
+  ...
+}: let
+  this-flake = import ../default.nix {inherit (config.deps.stdenv.buildPlatform) system;};
+  inherit (this-flake) inputs;
+  poetryLockRaw = lib.importTOML ../poetry.lock;
+  ruffVersion =
+    (
+      lib.findFirst
+      (p: p ? name && p.name == "ruff")
+      (lib.throw "ruff not found inside poetry.lock")
+      poetryLockRaw.package
+    )
+    .version;
+in {
+  imports = [
+    dream2nix.modules.dream2nix.rust-cargo-lock
+    dream2nix.modules.dream2nix.buildRustPackage
+  ];
+
+  deps = {nixpkgs, ...}: {
+    inherit
+      (nixpkgs)
+      installShellFiles
+      rust-jemalloc-sys
+      stdenv
+      ;
+    CoreServices =
+      if nixpkgs.stdenv.isDarwin
+      then nixpkgs.darwin.apple_sdk.frameworks.CoreServices
+      else null;
+    # For phases
+    ruff-nixpkgs = nixpkgs.ruff;
+  };
+
+  name = lib.mkForce "ruff";
+  version = lib.mkForce ruffVersion;
+
+  mkDerivation = {
+    src = inputs.ruff-source.outPath;
+    nativeBuildInputs = with config.deps; [
+      installShellFiles
+    ];
+    buildInputs = with config.deps; [
+      rust-jemalloc-sys
+      CoreServices
+    ];
+    inherit
+      (config.deps.ruff-nixpkgs)
+      postInstall
+      ;
+  };
+
+  public = {
+    meta = {
+      inherit
+        (config.deps.ruff-nixpkgs.meta)
+        description
+        mainProgram
+        ;
+    };
+  };
+}


### PR DESCRIPTION
This pull request ensures that the Nix Magic Cache consistently accesses the GitHub Actions Cache, even when evaluating pull requests. I hope it speeds up the formatting check.

This pull request also splits the `nix develop .#infra` check from the `nix flake check`. The latter may fail due to unpackaged Python dependencies, while we expect the former always to pass and stay in the cache.

Most importantly, this pull request integrates a Nix binary cache on Cachix (named [transcript-timestamper](https://app.cachix.org/cache/transcript-timestamper)) to cache the locally rebuilt ruff after each pull request merging, shortening the build time of the CI code format check. Cachix offers each user a 5GB (after compression) free-of-charge quota. That's quite enough for us so far.